### PR TITLE
Provide the coordinates used to access referenced cube names in getReferencedCubeNames

### DIFF
--- a/src/main/groovy/com/cedarsoftware/ncube/NCubeManager.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/NCubeManager.groovy
@@ -3,7 +3,6 @@ package com.cedarsoftware.ncube
 import com.cedarsoftware.ncube.util.CdnClassLoader
 import com.cedarsoftware.ncube.util.VersionComparator
 import com.cedarsoftware.util.ArrayUtilities
-import com.cedarsoftware.util.CaseInsensitiveSet
 import com.cedarsoftware.util.IOUtilities
 import com.cedarsoftware.util.MapUtilities
 import com.cedarsoftware.util.StringUtilities
@@ -558,7 +557,7 @@ class NCubeManager
     /**
      * Retrieve all cube names that are deeply referenced by ApplicationID + n-cube name.
      */
-    static void getReferencedCubeNames(ApplicationID appId, String name, Set<String> refs)
+    static void getReferencedCubeNames(ApplicationID appId, String name,  Set<String> refs)
     {
         if (refs == null)
         {
@@ -571,16 +570,18 @@ class NCubeManager
         {
             throw new IllegalArgumentException("Could not get referenced cube names, n-cube: ${name} does not exist in app: ${appId}")
         }
-        Set<String> subCubeList = ncube.referencedCubeNames
+
+        Map<Map, Set<String>> subCubeRefs = ncube.referencedCubeNames
 
         // TODO: Use explicit stack, NOT recursion
 
-        for (String cubeName : subCubeList)
-        {
-            if (!refs.contains(cubeName))
-            {
-                refs.add(cubeName)
-                getReferencedCubeNames(appId, cubeName, refs)
+        subCubeRefs.values().each { Set<String> cubeNames ->
+            cubeNames.each { String cubeName ->
+                if (!refs.contains(cubeName))
+                {
+                    refs.add(cubeName)
+                    getReferencedCubeNames(appId, cubeName, refs)
+                }
             }
         }
     }

--- a/src/test/groovy/com/cedarsoftware/ncube/NCubeBuilder.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/NCubeBuilder.groovy
@@ -1086,6 +1086,509 @@ class NCubeBuilder
 }''')
     }
 
+
+    static NCube  getCubeWithDefaultColumns()
+    {
+        return NCube.fromSimpleJson('''\
+{
+  "ncube": "test.CubeWithDefaultColumns",
+  "axes": [
+    {
+      "id": 1,
+      "name": "Axis1",
+      "hasDefault": true,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 1000527254003,
+          "type": "string",
+          "value": "Axis1Col1"
+        },
+        {
+          "id": 1001328925773,
+          "type": "string",
+          "value": "Axis1Col2"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Axis2",
+      "hasDefault": true,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 1,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 2000453853552,
+          "type": "string",
+          "value": "Axis2Col1"
+        },
+        {
+          "id": 2001566313159,
+          "type": "string",
+          "value": "Axis2Col2"
+        }
+      ]
+    }
+  ],
+  "cells": [
+    {
+      "id": [
+        1000527254003,
+        2000453853552
+      ],
+      "type": "exp",
+      "value": "@CubeA[:]"
+    },
+    {
+      "id": [],
+      "type": "exp",
+      "value": "@CubeD[:]"
+    },
+    {
+      "id": [
+        1001328925773,
+        2001566313159
+      ],
+      "type": "exp",
+      "value": "[]"
+    },
+    {
+      "id": [
+        1001328925773
+      ],
+      "type": "exp",
+      "value": "@CubeC[:]"
+    },
+    {
+      "id": [
+        2001566313159
+      ],
+      "type": "exp",
+      "value": "@CubeB[:]"
+    }
+  ]
+}''')
+    }
+
+
+    static NCube  getCubeWithAllDefaults()
+    {
+        return NCube.fromSimpleJson('''\
+{
+  "ncube": "test.CubeWithAllDefaults",
+  "defaultCellValueType": "exp",
+  "defaultCellValue": "@CubeLevelDefault[:]",
+  "axes": [
+    {
+      "id": 1,
+      "name": "Axis1",
+      "hasDefault": true,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 1000527254003,
+          "type": "string",
+          "value": "Axis1Col1"
+        },
+        {
+          "id": 1001328925773,
+          "type": "string",
+          "value": "Axis1Col2"
+        },
+        {
+          "id": 1001017210922,
+          "type": "string",
+          "default_value": {
+            "type": "exp",
+            "value": "@Axis1Col3Default[:]"
+          },
+          "value": "Axis1Col3"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Axis2",
+      "hasDefault": true,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 1,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 2000453853552,
+          "type": "string",
+          "value": "Axis2Col1"
+        },
+        {
+          "id": 2001566313159,
+          "type": "string",
+          "value": "Axis2Col2"
+        },
+        {
+          "id": 2000580973802,
+          "type": "string",
+          "default_value": {
+            "type": "exp",
+            "value": "@Axis2Col3Default[:]"
+          },
+          "value": "Axis2Col3"
+        }
+      ]
+    }
+  ],
+  "cells": [
+    {
+      "id": [
+        1000527254003,
+        2000453853552
+      ],
+      "type": "exp",
+      "value": "@CubeA[:]"
+    },
+    {
+      "id": [],
+      "type": "exp",
+      "value": "@CubeD[:]"
+    },
+    {
+      "id": [
+        1001328925773,
+        2001566313159
+      ],
+      "type": "exp",
+      "value": "[]"
+    },
+    {
+      "id": [
+        1001328925773
+      ],
+      "type": "exp",
+      "value": "@CubeC[:]"
+    },
+    {
+      "id": [
+        2001566313159
+      ],
+      "type": "exp",
+      "value": "@CubeB[:]"
+    }
+  ]
+}''')
+    }
+
+    static NCube  getCubeWithMultipleRefCubesPerCoord()
+    {
+        return NCube.fromSimpleJson('''\
+{
+  "ncube": "test.CubeWithMultipleRefCubesPerCoord",
+  "axes": [
+    {
+      "id": 1,
+      "name": "Axis1",
+      "hasDefault": false,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 1000527254003,
+          "type": "string",
+          "value": "Axis1Col1"
+        },
+        {
+          "id": 1001328925773,
+          "type": "string",
+          "value": "Axis1Col2"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Axis2",
+      "hasDefault": false,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 1,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 2000453853552,
+          "type": "string",
+          "value": "Axis2Col1"
+        },
+        {
+          "id": 2001566313159,
+          "type": "string",
+          "value": "Axis2Col2"
+        }
+      ]
+    }
+  ],
+  "cells": [
+    {
+      "id": [
+        1000527254003,
+        2000453853552
+      ],
+      "type": "exp",
+      "value": "@CubeA[:] && @CubeB[:]"
+    },
+    {
+      "id": [
+        1001328925773,
+        2001566313159
+      ],
+      "type": "exp",
+      "value": "@CubeA[:] && @CubeB[:] && @CubeC[:]"
+    }
+  ]
+}''')
+    }
+
+    static NCube  getRuleCubeWithAllDefaults()
+    {
+        return NCube.fromSimpleJson('''\
+{
+  "ncube": "test.RuleCubeWithAllDefaults",
+  "defaultCellValueType": "exp",
+  "defaultCellValue": "@CubeLevelDefault[:]",
+  "axes": [
+    {
+      "id": 2,
+      "name": "Axis2",
+      "hasDefault": false,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 1,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 2000453853552,
+          "type": "string",
+          "value": "Axis2Col1"
+        },
+        {
+          "id": 2001566313159,
+          "type": "string",
+          "default_value": {
+            "type": "exp",
+            "value": "@Axis2Col2Default[:]"
+          },
+          "value": "Axis2Col2"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "RuleAxis1",
+      "hasDefault": true,
+      "type": "RULE",
+      "valueType": "EXPRESSION",
+      "preferredOrder": 1,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 3000480286806,
+          "type": "exp",
+          "name": "Condition1",
+          "value": "@Condition1[:]"
+        },
+        {
+          "id": 3000155851047,
+          "type": "exp",
+          "name": "Condition2",
+          "value": "true"
+        }
+      ]
+    }
+  ],
+  "cells": [
+    {
+      "id": [
+        2000453853552,
+        3000480286806
+      ],
+      "type": "exp",
+      "value": "@CubeB[:]"
+    },
+    {
+      "id": [
+        2000453853552,
+        3000155851047
+      ],
+      "type": "exp",
+      "value": "[]"
+    },
+    {
+      "id": [
+        2001566313159,
+        3000155851047
+      ],
+      "type": "exp",
+      "value": "@CubeC[:]"
+    }
+  ]
+}''')
+    }
+
+    static NCube  getCubeWithColumnDefault()
+    {
+        return NCube.fromSimpleJson('''\
+{
+  "ncube": "test.CubeWithColumnDefault",
+  "axes": [
+    {
+      "id": 1,
+      "name": "Axis1",
+      "hasDefault": false,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 1000527254003,
+          "type": "string",
+          "value": "Axis1Col1"
+        },
+        {
+          "id": 1001328925773,
+          "type": "string",
+          "default_value": {
+            "type": "exp",
+            "value": "@Axis1Col2Default[:]"
+          },
+          "value": "Axis1Col2"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Axis2",
+      "hasDefault": false,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 1,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 2000453853552,
+          "type": "string",
+          "value": "Axis2Col1"
+        },
+        {
+          "id": 2001566313159,
+          "type": "string",
+          "value": "Axis2Col2"
+        }
+      ]
+    }
+  ],
+  "cells": [
+    {
+      "id": [
+        1000527254003,
+        2000453853552
+      ],
+      "type": "exp",
+      "value": "@CubeA[:]"
+    },
+    {
+      "id": [
+        1001328925773,
+        2001566313159
+      ],
+      "type": "exp",
+      "value": "[]"
+    }
+  ]
+}''')
+    }
+
+
+    static NCube  getCubeWithCubeDefault()
+    {
+        return NCube.fromSimpleJson('''\
+{
+  "ncube": "test.CubeWithCubeDefault",
+  "defaultCellValueType": "exp",
+  "defaultCellValue": "@CubeA[:]",
+  "axes": [
+    {
+      "id": 1,
+      "name": "Axis1",
+      "hasDefault": false,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 1000527254003,
+          "type": "string",
+          "value": "Axis1Col1"
+        },
+        {
+          "id": 1001328925773,
+          "type": "string",
+          "value": "Axis1Col2"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Axis2",
+      "hasDefault": false,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 1,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 2000453853552,
+          "type": "string",
+          "value": "Axis2Col1"
+        },
+        {
+          "id": 2001566313159,
+          "type": "string",
+          "value": "Axis2Col2"
+        }
+      ]
+    }
+  ],
+  "cells": [
+    {
+      "id": [
+        1000527254003,
+        2000453853552
+      ],
+      "type": "string",
+      "value": "not a reference"
+    },
+    {
+      "id": [
+        1001328925773,
+        2001566313159
+      ],
+      "type": "exp",
+      "value": "@CubeB[:]"
+    }
+  ]
+}''')
+    }
+
     static NCube getRuleWithOutboundRefs()
     {
         return NCube.fromSimpleJson('''\

--- a/src/test/groovy/com/cedarsoftware/ncube/TestGroovySourceParsing.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/TestGroovySourceParsing.groovy
@@ -1,9 +1,11 @@
 package com.cedarsoftware.ncube
 
+import com.cedarsoftware.util.CaseInsensitiveMap
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
+import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertTrue
 
 /**
@@ -44,23 +46,23 @@ class TestGroovySourceParsing
     void testFindCubeName()
     {
         NCube cube = NCubeManager.getNCubeFromResource 'inlineExpression.json'
-        Set<String> names = cube.referencedCubeNames
+        Map<CaseInsensitiveMap, Set<String>> names = cube.referencedCubeNames
 
-        assertTrue names.contains('Beretta')
-        assertTrue names.contains('Bersa')
-        assertTrue names.contains('Browning')
-        assertTrue names.contains('Car')
-        assertTrue names.contains('Colt')
-        assertTrue names.contains('FNHerstal')
-        assertTrue names.contains('Glock')
-        assertTrue names.contains('Kimber')
-        assertTrue names.contains('Marlin')
-        assertTrue names.contains('Mossberg')
-        assertTrue names.contains('Remington')
-        assertTrue names.contains('RockRiverArms')
-        assertTrue names.contains('Sig')
-        assertTrue names.contains('SnW')
-        assertTrue names.contains('Springfield')
-        assertTrue names.contains('Winchester')
+        assertEquals(['RockRiverArms'] as Set, names[[Age:'jump2'] as CaseInsensitiveMap])
+        assertEquals(['Bersa'] as Set, names[[Age:'absRef3'] as CaseInsensitiveMap])
+        assertEquals(['Springfield'] as Set, names[[Age:'relRef4'] as CaseInsensitiveMap])
+        assertEquals(['Marlin'] as Set, names[[Age:'jump3'] as CaseInsensitiveMap])
+        assertEquals(['Glock'] as Set, names[[Age:'ncubeRef1'] as CaseInsensitiveMap])
+        assertEquals(['Mossberg'] as Set, names[[Age:'relRef1'] as CaseInsensitiveMap])
+        assertEquals(['Browning'] as Set, names[[Age:'absRef4'] as CaseInsensitiveMap])
+        assertEquals(['Remington'] as Set, names[[Age:'jump4'] as CaseInsensitiveMap])
+        assertEquals(['Car'] as Set, names[[Age:'ncubeRef2'] as CaseInsensitiveMap])
+        assertEquals(['Beretta'] as Set, names[[Age:'absRef2'] as CaseInsensitiveMap])
+        assertEquals(['Sig'] as Set, names[[Age:'runRuleRef1'] as CaseInsensitiveMap])
+        assertEquals(['Kimber'] as Set, names[[Age:'relRef3'] as CaseInsensitiveMap])
+        assertEquals(['Colt'] as Set, names[[Age:'runRuleRef2'] as CaseInsensitiveMap])
+        assertEquals(['SnW'] as Set, names[[Age:'jump1'] as CaseInsensitiveMap])
+        assertEquals(['FNHerstal'] as Set, names[[Age:'relRef2'] as CaseInsensitiveMap])
+        assertEquals(['Winchester'] as Set, names[[Age:'absRef1'] as CaseInsensitiveMap])
     }
 }

--- a/src/test/groovy/com/cedarsoftware/ncube/TestNCube.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/TestNCube.groovy
@@ -4874,10 +4874,128 @@ class TestNCube
     void testGetReferencedCubeNamesOnRuleCubeWithDefault()
     {
         NCube ncube = NCubeBuilder.getRuleWithOutboundRefs()
-        Set<String> refs = ncube.getReferencedCubeNames()
+        Map<Map, Set<String>> refs = ncube.getReferencedCubeNames()
         assert refs.size() == 2
-        assert refs.contains('test.available')
-        assert refs.contains('test.price')
+
+        Map coord = [rule: "${'(availability): @test.available[:]'}"] as CaseInsensitiveMap
+        assert ['test.available'] as Set == refs[coord]
+
+        coord = [:] as CaseInsensitiveMap
+        assert ['test.price'] as Set == refs[coord]
+    }
+
+    @Test
+    void testGetReferencedCubeNamesOnCubeWithMultipleRefCubesPerCoord()
+    {
+        NCube ncube = NCubeBuilder.getCubeWithMultipleRefCubesPerCoord()
+        Map<Map, Set<String>> refs = ncube.getReferencedCubeNames()
+        assert refs.size() == 2
+
+        Map coord = [Axis1: 'Axis1Col1', Axis2: 'Axis2Col1'] as CaseInsensitiveMap
+        assert ['CubeA', 'CubeB'] as Set == refs[coord]
+
+        coord = [Axis1: 'Axis1Col2', Axis2: 'Axis2Col2'] as CaseInsensitiveMap
+        assert ['CubeA', 'CubeB', 'CubeC'] as Set == refs[coord]
+    }
+
+    @Test
+    void testGetReferencedCubeNamesOnCubeWithColumnDefault()
+    {
+        NCube ncube = NCubeBuilder.getCubeWithColumnDefault()
+        Map<Map, Set<String>> refs = ncube.getReferencedCubeNames()
+        assert refs.size() == 2
+
+        Map coord = [Axis1: 'Axis1Col1', Axis2: 'Axis2Col1'] as CaseInsensitiveMap
+        assert ['CubeA'] as Set == refs[coord]
+
+        coord = [Axis1: 'Axis1Col2'] as CaseInsensitiveMap
+        assert ['Axis1Col2Default'] as Set == refs[coord]
+      }
+
+    @Test
+    void testGetReferencedCubeNamesOnCubeWithCubeDefault()
+    {
+        NCube ncube = NCubeBuilder.getCubeWithCubeDefault()
+        Map<Map, Set<String>> refs = ncube.getReferencedCubeNames()
+        assert refs.size() == 2
+
+        Map coord = [Axis1: 'Axis1Col2', Axis2: 'Axis2Col2'] as CaseInsensitiveMap
+        assert ['CubeB'] as Set == refs[coord]
+
+        coord = [:] as CaseInsensitiveMap
+        assert ['CubeA'] as Set == refs[coord]
+    }
+
+    @Test
+    void testGetReferencedCubeNamesOnCubeWithDefaultColumns()
+    {
+        NCube ncube = NCubeBuilder.getCubeWithDefaultColumns()
+        Map<Map, Set<String>> refs = ncube.getReferencedCubeNames()
+        assert refs.size() == 4
+
+        Map coord = [Axis1: 'Axis1Col1', Axis2: 'Axis2Col1'] as CaseInsensitiveMap
+        assert ['CubeA'] as Set == refs[coord]
+
+        coord = [Axis1: 'default column', Axis2: 'Axis2Col2'] as CaseInsensitiveMap
+        assert ['CubeB'] as Set == refs[coord]
+
+        coord = [Axis1: 'Axis1Col2', Axis2: 'default column'] as CaseInsensitiveMap
+        assert ['CubeC'] as Set == refs[coord]
+
+        coord = [Axis1: 'default column', Axis2: 'default column'] as CaseInsensitiveMap
+        assert ['CubeD'] as Set == refs[coord]
+    }
+
+    @Test
+    void testGetReferencedCubeNamesOnCubeWithAllDefaults()
+    {
+        NCube ncube = NCubeBuilder.getCubeWithAllDefaults()
+        Map<Map, Set<String>> refs = ncube.getReferencedCubeNames()
+        assert refs.size() == 7
+
+        Map coord = [Axis1: 'Axis1Col1', Axis2: 'Axis2Col1'] as CaseInsensitiveMap
+        assert ['CubeA'] as Set == refs[coord]
+
+        coord = [Axis1: 'default column', Axis2: 'Axis2Col2'] as CaseInsensitiveMap
+        assert ['CubeB'] as Set == refs[coord]
+
+        coord = [Axis1: 'Axis1Col2', Axis2: 'default column'] as CaseInsensitiveMap
+        assert ['CubeC'] as Set == refs[coord]
+
+        coord = [Axis1: 'default column', Axis2: 'default column'] as CaseInsensitiveMap
+        assert ['CubeD'] as Set == refs[coord]
+
+        coord = [Axis1: 'Axis1Col3'] as CaseInsensitiveMap
+        assert ['Axis1Col3Default'] as Set == refs[coord]
+
+        coord = [Axis2: 'Axis2Col3'] as CaseInsensitiveMap
+        assert ['Axis2Col3Default'] as Set == refs[coord]
+
+        coord = [:] as CaseInsensitiveMap
+        assert ['CubeLevelDefault'] as Set == refs[coord]
+    }
+
+    @Test
+    void testGetReferencedCubeNamesOnRuleCubeWithAllDefaults()
+    {
+        NCube ncube = NCubeBuilder.getRuleCubeWithAllDefaults()
+        Map<Map, Set<String>> refs = ncube.getReferencedCubeNames()
+        assert refs.size() == 5
+
+        Map coord = [Axis2: 'Axis2Col1', RuleAxis1: "${'(Condition1): @Condition1[:]'}"] as CaseInsensitiveMap
+        assert ['CubeB'] as Set == refs[coord]
+
+        coord = [Axis2: 'Axis2Col2',  RuleAxis1: "${'(Condition2): true'}"] as CaseInsensitiveMap
+        assert ['CubeC'] as Set == refs[coord]
+
+        coord = [Axis2: 'Axis2Col2'] as CaseInsensitiveMap
+        assert ['Axis2Col2Default'] as Set == refs[coord]
+
+        coord = [RuleAxis1: "${'(Condition1): @Condition1[:]'}"] as CaseInsensitiveMap
+        assert ['Condition1'] as Set == refs[coord]
+
+        coord = [:] as CaseInsensitiveMap
+        assert ['CubeLevelDefault'] as Set == refs[coord]
     }
 
     @Test


### PR DESCRIPTION
1.	Changed NCube.getReferencedCubeNames to return a map keyed by cell coordinates within the specific NCube. Each map entry contains the cube names referenced by the cell coordinate in question.
2.	Changed NCubeManager.getReferencedCubeNames to handle a map being returned from NCube. getReferencedCubeNames, rather than a set.
3.	Added functionality to NCube.getReferencedCubeNames so that it also looks at column defaults set via meta properties.
