### PR TITLE
#271- remove oracle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,13 +248,6 @@
     </build>
 
     <dependencies>
-        
-        <dependency>
-            <groupId>com.oracle</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>12.2.0.1</version>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>


### PR DESCRIPTION
This PR removes ojdbc8 dependency which was causing the build to fail if oracle driver was not installed in local repo. It seems TestCopy.groovy was using this jar, but was  commented out but the pom file was not updated. Instead of testing with oracle driver, it would be appropriate use an im-memory database like h2 for testing.