### PR TITLE
- Updated runtime-server profile to always allow mutable methods

### DIFF
--- a/src/main/resources/config/ncube-beans.xml
+++ b/src/main/resources/config/ncube-beans.xml
@@ -66,7 +66,7 @@
         <bean id="ncubeRuntime" class="com.cedarsoftware.ncube.NCubeRuntime">
             <constructor-arg ref="callableBean"/>
             <constructor-arg ref="ncubeCacheManager"/>
-            <constructor-arg value="${ncube.allow.mutable.methods}"/>
+            <constructor-arg value="true"/>
         </bean>
 
         <bean id="callableBean" class="com.cedarsoftware.util.JsonHttpProxy">


### PR DESCRIPTION
A runtime-server should always allow mutable methods...that's the whole point. We always allow mutable methods for the combined-server. Simply updating this to match.