### PR TITLE
- Check for ncubeManager bean before trying to set userId on it

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 ### Revision History
+* 4.0.12
+  * Bug fix: Check for ncubeManager bean before trying to set userId on it
 * 4.0.11
   * Performance fix: removed Upper() from SQL statements on SHA-1 columns.
   * Added NCube.mapReduce() API.  Filter rows of an n-cube.  Use this API to fetch a subset of an n-cube, similar to SQL SELECT.

--- a/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
+++ b/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
@@ -98,8 +98,11 @@ class NCubeController implements NCubeConstants, RpmVisualizerConstants
             user = System.getProperty('user.name')
         }
 
-        NCubeManager manager = NCubeAppContext.getBean(MANAGER_BEAN) as NCubeManager
-        manager.userId = user
+        if (NCubeAppContext.containsBean(MANAGER_BEAN))
+        {
+            NCubeManager manager = NCubeAppContext.getBean(MANAGER_BEAN) as NCubeManager
+            manager.userId = user
+        }
         return user
     }
 


### PR DESCRIPTION
NCubeController.getUserForDatabase() was trying to set the userId on the NCubeManager. However, not all configurations will have both an NCubeController and an NCubeManager (for instance the runtime-server profile) so we need to check that it exists first.