### PR TITLE
Compile/Caching enhancements

### DIFF
--- a/src/main/groovy/com/cedarsoftware/config/NCubeConfiguration.groovy
+++ b/src/main/groovy/com/cedarsoftware/config/NCubeConfiguration.groovy
@@ -5,6 +5,7 @@ import com.cedarsoftware.ncube.util.NCubeRemoval
 import com.cedarsoftware.util.HsqlSchemaCreator
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.config.MethodInvokingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -54,6 +55,9 @@ class NCubeConfiguration
     @Value('${target.password}') String password
     @Value('${target.numConnections}') int numConnections
 
+    @Value('${ncube.sources.dir:#{null}}') String sourcesDirectory
+    @Value('${ncube.classes.dir:#{null}}') String classesDirectory
+
     @Bean(name = 'ncubeRemoval')
     NCubeRemoval getNCubeRemoval()
     {
@@ -72,6 +76,22 @@ class NCubeConfiguration
     {
         GCacheManager cacheManager = new GCacheManager(getNCubeRemoval(), maxSizePermCache, typePermCache, durationPermCache, unitsPermCache, concurrencyPermCache)
         return cacheManager
+    }
+
+    @Bean(name = 'setSourcesDir')
+    public MethodInvokingBean setSourcesDir() {
+        MethodInvokingBean methodInvokingBean = new MethodInvokingBean();
+        methodInvokingBean.setStaticMethod("com.cedarsoftware.ncube.GroovyBase.setGeneratedSourcesDirectory");
+        methodInvokingBean.setArguments([sourcesDirectory] as Object []);
+        return methodInvokingBean;
+    }
+
+    @Bean(name = 'setClassesDir')
+    public MethodInvokingBean setClassesDir() {
+        MethodInvokingBean methodInvokingBean = new MethodInvokingBean();
+        methodInvokingBean.setStaticMethod("com.cedarsoftware.ncube.util.CdnClassLoader.setGeneratedClassesDirectory");
+        methodInvokingBean.setArguments([classesDirectory] as Object []);
+        return methodInvokingBean;
     }
 
     @Configuration

--- a/src/main/groovy/com/cedarsoftware/ncube/CompileInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/CompileInfo.groovy
@@ -1,0 +1,74 @@
+package com.cedarsoftware.ncube
+
+import com.cedarsoftware.util.CaseInsensitiveMap
+import groovy.transform.CompileStatic
+
+/**
+ * This class contains information about the cube compilation.
+ *
+ * @author John DeRegnaucourt (jdereg@gmail.com)
+ *         <br>
+ *         Copyright (c) Cedar Software LLC
+ *         <br><br>
+ *         Licensed under the Apache License, Version 2.0 (the "License")
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *         <br><br>
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *         <br><br>
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ */
+@CompileStatic
+class CompileInfo extends CaseInsensitiveMap<String, Object>
+{
+    public static final String EXCEPTIONS = 'EXCEPTIONS'
+    public static final String CUBE_NAME = 'CUBE_NAME'
+
+    public static final String EXCEPTION_COORDINATES = 'COORDS'
+    public static final String EXCEPTION_INSTANCE = 'EXCEPTION'
+
+    CompileInfo()
+    {
+        put(EXCEPTIONS,[])
+    }
+
+    /**
+     * @return a String identifying cube name
+     */
+    String getCubeName()
+    {
+        return get(CUBE_NAME)
+    }
+
+    /**
+     * @return List of all exceptions that occurred during cube compilation. Each exception
+     * contains:
+     *      CUBE_NAME: a String with name of cube
+     *      COORDS: a Map of coordinates that refer to cell being compiled
+     *      EXCEPTION: the Exception caught during compile
+     */
+    List<Map> getExceptions()
+    {
+        return get(EXCEPTIONS) as List<Map>
+    }
+
+    /**
+     * Sets name of cube
+     */
+    protected void setCubeName(String cubeName)
+    {
+        put(CUBE_NAME,cubeName)
+    }
+
+    /**
+     * Adds exception to the list
+     */
+    protected void addException(Map coords, Exception e)
+    {
+        getExceptions() << [(EXCEPTION_COORDINATES):coords,(EXCEPTION_INSTANCE):e]
+    }
+}

--- a/src/main/groovy/com/cedarsoftware/ncube/GroovyBase.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/GroovyBase.groovy
@@ -329,7 +329,7 @@ abstract class GroovyBase extends UrlCommandCell
         try {
             sourceFile = new File("${sourcesDir}/${className.replace('.',File.separator)}.groovy")
             if (ensureDirectoryExists(sourceFile.getParent())) {
-                sourceFile.newWriter().withWriter { w -> w << groovySource }
+                sourceFile.bytes = StringUtilities.getUTF8Bytes(groovySource)
             }
         }
         catch (Exception e) {

--- a/src/main/groovy/com/cedarsoftware/ncube/GroovyBase.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/GroovyBase.groovy
@@ -22,7 +22,6 @@ import java.util.regex.Matcher
 import static com.cedarsoftware.ncube.NCubeAppContext.ncubeRuntime
 import static com.cedarsoftware.ncube.NCubeConstants.NCUBE_PARAMS_BYTE_CODE_DEBUG
 import static com.cedarsoftware.ncube.NCubeConstants.NCUBE_PARAMS_BYTE_CODE_VERSION
-import static com.cedarsoftware.ncube.NCubeConstants.NCUBE_PARAMS_GENERATED_SOURCES_DIR
 
 /**
  * Base class for Groovy CommandCells.
@@ -56,7 +55,7 @@ abstract class GroovyBase extends UrlCommandCell
      * class (URL to groovy), yet have different source code for that class.
      */
     private static final ConcurrentMap<ApplicationID, ConcurrentMap<String, Class>> L2_CACHE = new ConcurrentHashMap<>()
-    private static String generatedSourcesDir
+    private static String generatedSourcesDir = ''
 
     //  Private constructor only for serialization.
     protected GroovyBase() {}
@@ -343,13 +342,8 @@ abstract class GroovyBase extends UrlCommandCell
      * Returns directory to use for writing source files, if configured and valid
      * @return String specifying valid directory or empty string, if not configured or specified directory was not valid
      */
-    protected static String getGeneratedSourcesDirectory()
+    public static String getGeneratedSourcesDirectory()
     {
-        if (generatedSourcesDir==null)
-        {   // default to SystemParams, if not configured
-            setGeneratedSourcesDirectory(ncubeRuntime.getSystemParams()[NCUBE_PARAMS_GENERATED_SOURCES_DIR] as String ?: '')
-        }
-
         return generatedSourcesDir
     }
 
@@ -362,17 +356,17 @@ abstract class GroovyBase extends UrlCommandCell
      *      valid directory - directory to use for generated sources
      *   NOTE: if directory cannot be validated, generated sources will be disabled
      */
-    protected static void setGeneratedSourcesDirectory(String sourcesDir)
+    public static void setGeneratedSourcesDirectory(String sourcesDir)
     {
         try
         {
-            if (sourcesDir==null)
+            if (sourcesDir)
             {
-                generatedSourcesDir = null // allows sources to be reloaded
+                generatedSourcesDir = ensureDirectoryExists(sourcesDir) ? sourcesDir : ''
             }
             else
             {
-                generatedSourcesDir = ensureDirectoryExists(sourcesDir) ? sourcesDir : ''
+                generatedSourcesDir = ''
             }
 
             if (generatedSourcesDir)

--- a/src/main/groovy/com/cedarsoftware/ncube/NCube.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/NCube.groovy
@@ -974,30 +974,33 @@ class NCube<T>
     /**
      * Pre-compile command cells, meta-properties, and rule conditions that are expressions
      */
-    void compile()
+    CompileInfo compile()
     {
+        CompileInfo compileInfo = new CompileInfo()
+        compileInfo.setCubeName(this.name)
+
         cells.each { ids, cell ->
             if(cell instanceof GroovyBase) {
-                compileCell(getCoordinateFromIds(ids), cell as GroovyBase)
+                compileCell(getCoordinateFromIds(ids), cell as GroovyBase, compileInfo)
             }
         }
 
         metaProps.each { key, value ->
             if (value instanceof GroovyBase) {
-                compileCell([metaProp:key],value as GroovyBase)
+                compileCell([metaProp:key],value as GroovyBase, compileInfo)
             }
         }
 
         axisList.each { axisName, axis ->
             axis.columns.each { column ->
                 if (column.value instanceof GroovyBase) {
-                    compileCell([axis:axisName,column:column.columnName],column.value as GroovyBase)
+                    compileCell([axis:axisName,column:column.columnName],column.value as GroovyBase, compileInfo)
                 }
 
                 if (column.metaProps) {
                     column.metaProps.each { key, value ->
                         if (value instanceof GroovyBase) {
-                            compileCell([axis:axisName,column:column.columnName,metaProp:key],value as GroovyBase)
+                            compileCell([axis:axisName,column:column.columnName,metaProp:key],value as GroovyBase, compileInfo)
                         }
                     }
                 }
@@ -1006,20 +1009,23 @@ class NCube<T>
             if (axis.metaProps) {
                 axis.metaProps.each { key, value ->
                     if (value instanceof GroovyBase) {
-                        compileCell([axis:axisName,metaProp:key],value as GroovyBase)
+                        compileCell([axis:axisName,metaProp:key],value as GroovyBase, compileInfo)
                     }
                 }
             }
         }
+
+        return compileInfo
     }
 
-    private void compileCell(Map input, GroovyBase groovyBase) {
+    private void compileCell(Map input, GroovyBase groovyBase, CompileInfo compileInfo) {
         try
         {
             groovyBase.prepare(groovyBase.cmd ?: groovyBase.url, prepareExecutionContext(input,[:]))
         }
         catch (Exception e)
         {
+            compileInfo.addException(input,e)
             LOG.warn("Failed to compile cell for cube:${this.name} with coords:${input.toString()}",e)
         }
     }

--- a/src/main/groovy/com/cedarsoftware/ncube/NCubeConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/NCubeConstants.groovy
@@ -70,8 +70,6 @@ interface NCubeConstants
     final String NCUBE_PARAMS_BYTE_CODE_VERSION = 'byteCodeVersion'
     final String NCUBE_ACCEPTED_DOMAINS = 'acceptedDomains'
     final String NCUBE_PARAMS_BRANCH = 'branch'
-    final String NCUBE_PARAMS_GENERATED_SOURCES_DIR = 'sourcesDir'
-    final String NCUBE_PARAMS_GENERATED_CLASSES_DIR = 'classesDir'
 
     final String PR_PROP = 'property'
     final String PR_STATUS = 'status'

--- a/src/main/groovy/com/cedarsoftware/ncube/util/CdnClassLoader.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/util/CdnClassLoader.groovy
@@ -94,7 +94,7 @@ class CdnClassLoader extends GroovyClassLoader
         addURLs(urlList)
     }
 
-/**
+    /**
      * Caches the class, if name is supplied and caching is configured,
      * then delegates to super class to defineClass from raw bytes
      *

--- a/src/main/groovy/com/cedarsoftware/ncube/util/CdnClassLoader.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/util/CdnClassLoader.groovy
@@ -94,11 +94,6 @@ class CdnClassLoader extends GroovyClassLoader
         addURLs(urlList)
     }
 
-    @Override
-    protected Class loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        return loadClass(name, false, true, resolve)
-    }
-
 /**
      * Caches the class, if name is supplied and caching is configured,
      * then delegates to super class to defineClass from raw bytes

--- a/src/main/groovy/com/cedarsoftware/ncube/util/CdnClassLoader.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/util/CdnClassLoader.groovy
@@ -115,18 +115,16 @@ class CdnClassLoader extends GroovyClassLoader
     /**
      * Writes the generated Groovy class to the directory identified by the NCUBE_PARAM:genClsDir
      * @param name String of fully qualified name of the class
-     * @param bytes byte [] of Class to write
+     * @param byteCode byte [] of Class to write
      */
-    private void dumpGeneratedClass(String name, byte [] bytes) {
+    private void dumpGeneratedClass(String name, byte [] byteCode) {
         File classFile = null
         try
         {
             classFile = new File("${generatedClassesDir}/${name.replace('.',File.separator)}.class")
             if (ensureDirectoryExists(classFile.getParentFile()))
             {
-                classFile.newOutputStream().withStream { stream ->
-                    stream.write(bytes)
-                }
+                classFile.bytes = byteCode
             }
         }
         catch (Exception e)

--- a/src/test/groovy/com/cedarsoftware/ncube/TestL3Cache.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/TestL3Cache.groovy
@@ -160,6 +160,9 @@ class TestL3Cache extends NCubeCleanupBaseTest
     @Test
     void testCompile()
     {
+        ncubeRuntime.systemParams[NCUBE_ACCEPTED_DOMAINS] = 'org.apache.'
+        reloadCubes('sys.classpath.L3Cache.json')
+
         testCube.compile()
 
         // exercise ncube in a variety of ways to invoke cells and meta properties

--- a/src/test/groovy/com/cedarsoftware/ncube/TestL3Cache.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/TestL3Cache.groovy
@@ -399,7 +399,7 @@ class TestL3Cache extends NCubeCleanupBaseTest
         output.clear()
         testCube.getCell([name:'grab'],output)
         assertEquals(expClass.name,findLoadedClass(expClass).name)
-        verifySourceFileExistence(expClass,false)
+        verifySourceFileExistence(expClass,true)    // verify recompile occurred
     }
 
     /**

--- a/src/test/groovy/com/cedarsoftware/ncube/TestL3Cache.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/TestL3Cache.groovy
@@ -1,6 +1,7 @@
 package com.cedarsoftware.ncube
 
 import com.cedarsoftware.ncube.util.CdnClassLoader
+import org.codehaus.groovy.control.CompilationFailedException
 import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
@@ -163,7 +164,14 @@ class TestL3Cache extends NCubeCleanupBaseTest
         ncubeRuntime.systemParams[NCUBE_ACCEPTED_DOMAINS] = 'org.apache.'
         reloadCubes('sys.classpath.L3Cache.json')
 
-        testCube.compile()
+        CompileInfo compileInfo = testCube.compile()
+        List<Map> exceptions = compileInfo.getExceptions()
+        assertEquals(exceptions.toString(),1,exceptions.size())
+        Map cellException = exceptions.first()
+        assertEquals(cellException.toString(),'test.L3CacheTest',compileInfo.getCubeName())
+        assertEquals(cellException.toString(),'cellException',cellException[CompileInfo.EXCEPTION_COORDINATES]['name'])
+        Exception compileException = cellException[CompileInfo.EXCEPTION_INSTANCE] as Exception
+        assertTrue(cellException.toString(),compileException instanceof CompilationFailedException)
 
         // exercise ncube in a variety of ways to invoke cells and meta properties
         Map output = [:]

--- a/src/test/groovy/com/cedarsoftware/ncube/TestNCubeIntegration.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/TestNCubeIntegration.groovy
@@ -176,7 +176,7 @@ class TestNCubeIntegration extends NCubeCleanupBaseTest
         coord.put("method", "doIt")
         coord.put("age", 25)
         ncube.setCell(new GroovyMethod(
-                "package ncube.grv.method; class Junk extends NCubeGroovyController " +
+                "package ncube.grv.method; class JunkTwo extends NCubeGroovyController " +
                         "{\n" +
                         "def doIt() {\n" +
                         " int x = input.age * 10;" +
@@ -213,7 +213,7 @@ class TestNCubeIntegration extends NCubeCleanupBaseTest
         coord.put("age", 25)
         coord.put("method", "doIt")
         ncube.setCell(new GroovyMethod(
-                "package ncube.grv.method; class Junk extends NCubeGroovyController {" +
+                "package ncube.grv.method; class JunkTwoClass extends NCubeGroovyController {" +
                         "def doIt()" +
                         "{" +
                         " int x = input['age'] * 10;" +

--- a/src/test/groovy/com/cedarsoftware/ncube/util/TestCdnClassLoader.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/util/TestCdnClassLoader.groovy
@@ -4,8 +4,10 @@ import com.cedarsoftware.ncube.NCubeBaseTest
 import groovy.transform.CompileStatic
 import org.junit.Test
 
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertTrue
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
  *         <br/>
@@ -73,5 +75,22 @@ class TestCdnClassLoader extends NCubeBaseTest
         }
         catch (NoSuchElementException ignore)
         { }
+    }
+
+    @Test
+    void testGetResourcesMultipleTimes()
+    {
+        CdnClassLoader loader = new CdnClassLoader(TestCdnClassLoader.class.classLoader)
+
+        String resourceName = 'config/hsqldb-schema.sql'
+        Enumeration<URL> urls = loader.getResources(resourceName)
+        assertTrue(urls.hasMoreElements())
+        assertNotNull(urls.nextElement())
+        assertFalse(urls.hasMoreElements())
+
+        urls = loader.getResources(resourceName)
+        assertTrue(urls.hasMoreElements())
+        assertNotNull(urls.nextElement())
+        assertFalse(urls.hasMoreElements())
     }
 }

--- a/src/test/resources/files/ncube/UrlToBlock.groovy
+++ b/src/test/resources/files/ncube/UrlToBlock.groovy
@@ -1,0 +1,1 @@
+output.urlToBlock = this.class

--- a/src/test/resources/files/ncube/UrlToClass.groovy
+++ b/src/test/resources/files/ncube/UrlToClass.groovy
@@ -1,0 +1,11 @@
+package files.ncube
+
+import ncube.grv.exp.NCubeGroovyExpression
+
+class UrlToClass extends NCubeGroovyExpression
+{
+    def run()
+    {
+        output.urlToClass = this.class
+    }
+}

--- a/src/test/resources/sys.classpath.L3cache.json
+++ b/src/test/resources/sys.classpath.L3cache.json
@@ -1,0 +1,21 @@
+{
+    "ncube": "sys.classpath",
+    "axes": [
+        {
+            "name": "env",
+            "type": "DISCRETE",
+            "valueType": "STRING",
+            "preferredOrder": 1,
+            "hasDefault": true,
+            "columns": []
+        }
+    ],
+    "cells": [
+        {
+            "id": [],
+            "type": "exp",
+            "cache" : true,
+            "value": "GroovyClassLoader parent = new GroovyClassLoader(CdnClassLoader.class.classLoader)\nparent.addURL(new File('src/test/scripts').toURI().toURL())\nCdnClassLoader cdn = new CdnClassLoader(parent)\ncdn.addURL('http://files.cedarsoftware.com')\nreturn cdn"
+        }
+    ]
+}

--- a/src/test/scripts/files/ncube/UrlToRemoteBlock.groovy
+++ b/src/test/scripts/files/ncube/UrlToRemoteBlock.groovy
@@ -1,0 +1,1 @@
+output.urlToRemoteBlock = this.class

--- a/src/test/scripts/files/ncube/UrlToRemoteClass.groovy
+++ b/src/test/scripts/files/ncube/UrlToRemoteClass.groovy
@@ -1,0 +1,11 @@
+package files.ncube
+
+import ncube.grv.exp.NCubeGroovyExpression
+
+class UrlToRemoteClass extends NCubeGroovyExpression
+{
+    def run()
+    {
+        output.urlToRemoteClass = this.class
+    }
+}

--- a/src/test/scripts/files/ncube/UrlToShortcutBlock.groovy
+++ b/src/test/scripts/files/ncube/UrlToShortcutBlock.groovy
@@ -1,0 +1,2 @@
+@([name:'urlToRemoteBlock'])
+output.urlToShortcutBlock = this.class

--- a/src/test/scripts/files/ncube/UrlToShortcutClass.groovy
+++ b/src/test/scripts/files/ncube/UrlToShortcutClass.groovy
@@ -1,0 +1,12 @@
+package files.ncube
+
+import ncube.grv.exp.NCubeGroovyExpression
+
+class UrlToShortcutClass extends NCubeGroovyExpression
+{
+    def run()
+    {
+        @([name:'urlToRemoteClass'])
+        output.urlToShortcutClass = this.class
+    }
+}


### PR DESCRIPTION
- Change caching configuration to use application.properties instead of ncube_params
- Change NCube.compile to return CompileInfo
- Use source generated by buildGroovy in L2CacheKey, instead of building twice
- Added tests to validate grab is handled correctly by caching