### PR TITLE
Update ApplicationID.asBootVersion() to automatically use snapshot version

### DIFF
--- a/src/main/groovy/com/cedarsoftware/ncube/ApplicationID.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/ApplicationID.groovy
@@ -250,7 +250,7 @@ class ApplicationID
 
     ApplicationID asBootVersion()
     {
-        return this.asVersion(SYS_BOOT_VERSION)
+        return this.asVersion(SYS_BOOT_VERSION).asSnapshot()
     }
 
     /**


### PR DESCRIPTION
Hey John,

Currently, if asBootVersion() is called from a RELEASE version of ApplicationID, the user will end up with 0.0.0-RELEASE, which can never exist.