### PR TITLE
Remove redundant asSnapshot() from NCubeRuntime

### DIFF
--- a/src/main/groovy/com/cedarsoftware/ncube/NCubeRuntime.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/NCubeRuntime.groovy
@@ -159,7 +159,7 @@ class NCubeRuntime implements NCubeMutableClient, NCubeRuntimeClient, NCubeTestC
         }
         try
         {   // Do not remove try-catch handler in favor of advice handler
-            ApplicationID bootVersionAppId = appId.asBootVersion().asSnapshot()
+            ApplicationID bootVersionAppId = appId.asBootVersion()
             NCube menuCube = getCubeInternal(bootVersionAppId, SYS_MENU)
             if (menuCube == null)
             {


### PR DESCRIPTION
Remove redundant asSnapshot() from NCubeRuntime in conjuction with corresponding addition of asSnapshot() in ApplicationID asBootVersion()