### PR TITLE
New configuration: "ncube.legacy.grv.exp". Also NCube.getMap coord-copying fixes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 ### Revision History
+* 4.8.2
+  * Added support for ncube.legacy.grv.exp configuration for backwards compatibility in `NCubeGroovyExpression`
+  * Fixed `NCube.getMap` not copying the coordinate map before modifying it
 * 4.8.1
   * Updated `RulesEngine` documentation to handle orchestration NCubes that end in the same string after the last`.` in the name.
 * 4.8.0

--- a/src/main/groovy/com/cedarsoftware/config/NCubeConfiguration.groovy
+++ b/src/main/groovy/com/cedarsoftware/config/NCubeConfiguration.groovy
@@ -17,6 +17,7 @@ import com.cedarsoftware.util.HsqlSchemaCreator
 import com.cedarsoftware.util.JsonHttpProxy
 import com.cedarsoftware.util.ReflectiveProxy
 import groovy.transform.CompileStatic
+import ncube.grv.exp.NCubeGroovyExpression
 import org.apache.http.HttpHost
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -118,6 +119,10 @@ class NCubeConfiguration
 
     // Limit size of coordinate displayed in each CommandCell exception list (--> [coordinate])
     @Value('${ncube.stackEntry.coordinate.value.max:1000}') int stackEntryCoordinateValueMaxSize
+
+    // If true, "at" type methods on NCubeGroovyExpression will add their coords to their input map.
+    // This is legacy behavior that is probably not desirable going forward. We're allowing it for backwards compatibility.
+    @Value('${ncube.legacy.grv.exp:false}') boolean legacyNCubeGroovyExpression
 
     @Bean(name = 'ncubeRemoval')
     Closure getNcubeRemoval()
@@ -280,6 +285,7 @@ class NCubeConfiguration
         CdnClassLoader.generatedClassesDirectory = classesDirectory
         GroovyBase.generatedSourcesDirectory = sourcesDirectory
         NCube.stackEntryCoordinateValueMaxSize = stackEntryCoordinateValueMaxSize
+        NCubeGroovyExpression.legacyNCubeGroovyExpression = legacyNCubeGroovyExpression
     }
 
     @Profile('test-database')

--- a/src/main/groovy/com/cedarsoftware/ncube/NCube.groovy
+++ b/src/main/groovy/com/cedarsoftware/ncube/NCube.groovy
@@ -1171,8 +1171,9 @@ class NCube<T>
 
         for (column in columns)
         {
-            coord.put(axisName, wildcardAxis.getValueToLocateColumn(column))
-            result.put(column.value, getCell(coord, output, defaultValue))
+            final Map params = new CompactCILinkedMap<>(coord)
+            params.put(axisName, wildcardAxis.getValueToLocateColumn(column))
+            result.put(column.value, getCell(params, output, defaultValue))
         }
 
         return result

--- a/src/main/groovy/ncube/grv/exp/NCubeGroovyExpression.groovy
+++ b/src/main/groovy/ncube/grv/exp/NCubeGroovyExpression.groovy
@@ -47,6 +47,7 @@ class NCubeGroovyExpression
     public Map output
     public NCube ncube
     private static NCubeMutableClient mutableClient = null
+    private static boolean legacyNCubeGroovyExpression = false
 
     /**
      * Fetch the named n-cube from the NCubeRuntime.  It looks at the same
@@ -251,7 +252,7 @@ class NCubeGroovyExpression
     def use(Map altInput, String cubeName = ncube.name, def defaultValue = null)
     {
         Map copy = inputWithoutTrackingMap
-        Map origInput = dupe(copy)
+        Map origInput = new CompactCILinkedMap(copy)
         Map modInput = dupe(copy)
         modInput.putAll(altInput)
         return getCube(cubeName).use(modInput, origInput, output, defaultValue)
@@ -280,7 +281,7 @@ class NCubeGroovyExpression
         }
 
         Map copy = inputWithoutTrackingMap
-        Map origInput = dupe(copy)
+        Map origInput = new CompactCILinkedMap(copy)
         Map modInput = dupe(copy)
         modInput.putAll(altInput)
         return target.use(modInput, origInput, output, defaultValue)
@@ -298,7 +299,7 @@ class NCubeGroovyExpression
 
     private Map dupe(Map map)
     {
-        return new CompactCILinkedMap(map)
+        return legacyNCubeGroovyExpression ? map : new CompactCILinkedMap(map)
     }
 
     /**
@@ -522,5 +523,15 @@ class NCubeGroovyExpression
     Object run()
     {
         throw new IllegalStateException("run() should never be called on ${getClass().name}. This can occur for a cell marked GroovyExpression which should be set to GroovyMethod. NCube: ${ncube.name}, input: ${input.toString()}")
+    }
+
+    /**
+     * If true, "at" type methods on NCubeGroovyExpression will add their coords to their input map.
+     * This is legacy behavior that is probably not desirable going forward. We're allowing it for backwards compatibility.
+     * @param arg boolean
+     */
+    static void setLegacyNCubeGroovyExpression(boolean arg)
+    {
+        legacyNCubeGroovyExpression = arg
     }
 }

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -196,6 +196,12 @@
       "name": "ncube.rules.engines",
       "type": "java.util.List<Map<String, String>>",
       "description": "List of rules engines. See README.md for more information."
+    },
+    {
+      "name": "ncube.legacy.grv.exp",
+      "type": "java.lang.Boolean",
+      "description": "If true, \"at\" type methods on NCubeGroovyExpression will add their coords to their input map. This is legacy behavior that is probably not desirable going forward. We're allowing it for backwards compatibility.",
+      "defaultValue": "false"
     }
   ]
 }

--- a/src/test/groovy/com/cedarsoftware/ncube/TestNCube.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/TestNCube.groovy
@@ -13,6 +13,7 @@ import com.cedarsoftware.util.CaseInsensitiveMap
 import groovy.transform.CompileStatic
 import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
+import ncube.grv.exp.NCubeGroovyExpression
 import org.junit.Test
 
 import static com.cedarsoftware.ncube.NCubeAppContext.ncubeRuntime
@@ -3137,6 +3138,18 @@ class TestNCube extends NCubeBaseTest
         assertEquals("EQM", coord.Bu)
         assertEquals("WY", coord.State)
         assertEquals("1", x)
+
+        try {
+            NCubeGroovyExpression.legacyNCubeGroovyExpression = true
+            x = (String) ncube.getCell(coord)
+            assertEquals("EQM", coord.Bu)
+            assertEquals("WY", coord.State)
+            assertEquals("10", x)
+        }
+        finally
+        {
+            NCubeGroovyExpression.legacyNCubeGroovyExpression = false
+        }
 
         Set<String> scope = ncube.getRequiredScope([:], [:])
         assertTrue(scope.size() == 2)

--- a/src/test/groovy/com/cedarsoftware/ncube/TestNCube.groovy
+++ b/src/test/groovy/com/cedarsoftware/ncube/TestNCube.groovy
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotEquals
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertSame
 import static org.junit.Assert.assertTrue
 import static org.junit.Assert.fail
 
@@ -1880,14 +1881,14 @@ class TestNCube extends NCubeBaseTest
 
         set.clear()
         set.add("Male")
-        coord.Gender = set
+        assertSame(coord.Gender, set)
         result = ncube.getMap(coord)
         assertFalse("f".equals(result.Female))
         assertTrue("m".equals(result.Male))
 
         set.clear()
         set.add("Snail")
-        coord.Gender = set
+        assertSame(coord.Gender, set)
         result = ncube.getMap(coord)
         assertTrue(result.size() == 1)
         assertTrue("DEFAULT VALUE".equals(result.get(null)))
@@ -3109,22 +3110,32 @@ class TestNCube extends NCubeBaseTest
         coord.put("Bu", "PIM")
         coord.put("State", "GA")
         String x = (String) ncube.getCell(coord)
+        assertEquals("PIM", coord.Bu)
+        assertEquals("GA", coord.State)
         assertEquals("1", x)
 
         coord.put("state", "OH")
         x = (String) ncube.getCell(coord)
+        assertEquals("PIM", coord.Bu)
+        assertEquals("OH", coord.State)
         assertEquals("2", x)
 
         coord.put("STATE", "TX")
         x = (String) ncube.getCell(coord)
+        assertEquals("PIM", coord.Bu)
+        assertEquals("TX", coord.State)
         assertEquals("3", x)
 
         coord.put("state", "WY")
         x = (String) ncube.getCell(coord)
+        assertEquals("PIM", coord.Bu)
+        assertEquals("WY", coord.State)
         assertEquals("4", x)
 
         coord.put("bu", "EQM")
         x = (String) ncube.getCell(coord)
+        assertEquals("EQM", coord.Bu)
+        assertEquals("WY", coord.State)
         assertEquals("1", x)
 
         Set<String> scope = ncube.getRequiredScope([:], [:])

--- a/src/test/resources/testAtCommand.json
+++ b/src/test/resources/testAtCommand.json
@@ -124,7 +124,7 @@
             {
                 "key":{"bu":"EQM","state":"WY"},
                 "type":"exp",
-                "value":"@([bu:'EQM',state:'GA'])"
+                "value":"@([bu:'ALT']); return @([state:'GA'])"
             }
         ]
 }


### PR DESCRIPTION
Added support for ncube.legacy.grv.exp configuration for backwards compatibility in `NCubeGroovyExpression`
Fixed `NCube.getMap` not copying the coordinate map before modifying it